### PR TITLE
Allow for empty rules in top-level stylelintrc / stylelint.config.js

### DIFF
--- a/lib/utils/rules.js
+++ b/lib/utils/rules.js
@@ -56,7 +56,7 @@ const getUsedRules = (config, allRules = null) => {
     }
 
     const _gatherRules = (_config) => {
-        const rulesNames = Object.keys(_config.rules);
+        const rulesNames = Object.keys(_config.rules || {});
 
         // - Extends
         if (_config.extends) {


### PR DESCRIPTION
when you have a top-level configuration file like 

```
module.exports = {
  extends: './src/configurations/base.js',
};
```
and that file is does not contain a "rules" object, `_config.rules` is undefined and should therefore have a default. 

adding the rules object to the top-level stylelint.config.js is a temporary fix:
```
module.exports = {
  extends: './src/configurations/base.js',
  rules: {},
};
```