### PR TITLE
Fix CHANGELOG formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0 (2019-11-30)
+## 1.2.0 (2019-11-30)
 - Update dev dependencies.
 - Add stylelint 12 to supported peer dependency versions.
 


### PR DESCRIPTION
Thank you for maintaining this package!

Small change – the 1.2.0 heading wasn’t displaying as a heading in GitHub due to the space character being used.