### PR TITLE
Fix peerDependencies declaration for Stylelint 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "stylelint": "^15"
     },
     "peerDependencies": {
-        "stylelint": "^14 || ^15"
+        "stylelint": "^14.2.0 || ^15"
     },
     "engines": {
         "node": ">=10"


### PR DESCRIPTION
The `resolveConfig` function from Stylelint’s Node API is only available [in v14.2.0](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md#1420).

With Stylelint 14.1.0, I got the following error:

```
Error: resolveConfig is not a function
```